### PR TITLE
Refactor external content link handling to use message posting from frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavecx-react-native",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "React Native library for WaveCX",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -265,28 +265,23 @@ export const WaveCxProvider = (props: {
               ref={webViewRef}
               style={!isRemoteContentReady ? styles.hidden : undefined}
               onLoad={() => setIsRemoteContentReady(true)}
-              onShouldStartLoadWithRequest={(request) => {
-                const isInternalLink =
-                  request.url.split('//')[1]?.split('/')[0] ===
-                  activeContentItem?.viewUrl.split('//')[1]?.split('/')[0];
+              onMessage={(message) => {
+                try {
+                  const messageData = JSON.parse(message.nativeEvent.data);
+                  if (messageData.type === 'link-requested') {
+                    let isDefaultPrevented = false;
+                    props.onLinkRequested?.(messageData.url, {
+                      dismissContent,
+                      preventDefault: () => {
+                        isDefaultPrevented = true;
+                      },
+                    });
 
-                if (isInternalLink || !request.isTopFrame) {
-                  return true;
-                }
-
-                let isDefaultPrevented = false;
-                props.onLinkRequested?.(request.url, {
-                  dismissContent,
-                  preventDefault: () => {
-                    isDefaultPrevented = true;
-                  },
-                });
-
-                if (!isDefaultPrevented) {
-                  Linking.openURL(request.url);
-                }
-
-                return false;
+                    if (!isDefaultPrevented) {
+                      Linking.openURL(messageData.url);
+                    }
+                  }
+                } catch {}
               }}
             />
           </>


### PR DESCRIPTION
Inconsistencies in react-web-view's handling of HTML links between iOS and android caused problems getting `onLinkRequested` invoked reliably.

This refactor listens for events posted from our web UI, guaranteeing that external content links will be correctly provided to the web view.