### PR TITLE
feat: add hasContent, onContentCacheChanged, and triggerPoint for user-triggered content

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,21 +102,43 @@ When a trigger-point event is raised, WaveCX will check for and
 present any content set for that trigger point that is relevant
 for the current user.
 
+### Checking for Content
+The WaveCX context provides a `hasContent` method to check whether
+content exists for a given trigger point without presenting it.
+An optional second parameter filters by presentation type.
+
+`hasContent` is reactive — components that call it in render will
+automatically rerender when the content cache changes (e.g. after
+session start, trigger point consumption, or session end).
+
+```ts
+const { hasContent } = useWaveCx();
+
+// check if any content exists for a trigger point
+hasContent('trigger-point-code');
+
+// check for a specific presentation type
+hasContent('trigger-point-code', 'popup');
+hasContent('trigger-point-code', 'button-triggered');
+```
+
 ### User-Triggered Content
-The WaveCX context provides a boolean value `hasUserTriggeredContent`
-indicating if the current trigger point has user-triggered
-content available. To present this content, a `user-triggered-content`
-event should be fired:
+Use `hasContent` to check for user-triggered content availability
+and fire a `user-triggered-content` event to present it. The
+event accepts an optional `triggerPoint` parameter to specify
+which trigger point's content to show. If omitted, it falls back
+to the content set by the most recently fired trigger-point event.
 
 ```tsx
-const { handleEvent, hasUserTriggeredContent } = useWaveCx();
+const { handleEvent, hasContent } = useWaveCx();
 
 // in render
-{hasUserTriggeredContent && (
+{hasContent('trigger-point-code', 'button-triggered') && (
   <Button
     title={'User-Triggered Content'}
     onPress={() => handleEvent({
       type: 'user-triggered-content',
+      triggerPoint: 'trigger-point-code',
       onContentDismissed: () => {
         // optional callback when content closed by user
       }
@@ -124,6 +146,10 @@ const { handleEvent, hasUserTriggeredContent } = useWaveCx();
   />
 )}
 ```
+
+> **Deprecation notice:** `hasUserTriggeredContent` is deprecated.
+> It only reflects content state for the most recently fired trigger
+> point. Use `hasContent(triggerPoint, 'button-triggered')` instead.
 
 ### Session Ended Events
 If trigger points may still be reached in your application

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ application tree.
 | maxFontSizeMultiplier  | number                              | maximum OS-level font scaling multiplier                                                                                              | false    |                                                                 |
 | headerTitleStyle       | TextStyle                           | styles to apply to modal header title                                                                                                 | false    |                                                                 |
 | headerCloseButtonStyle | TextStyle                           | styles to apply to the modal close button text                                                                                        | false    |                                                                 |
+| onContentCacheChanged  | function (TargetedContent[]) => void | callback fired whenever the content cache changes, receiving the current cache contents. Useful for syncing content state to an external store | false    |                                                                 |
 
 #### Types
 ```ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavecx-react-native",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "React Native library for WaveCX",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -361,4 +361,353 @@ describe(WaveCxProvider.name, () => {
     await user.press(getByText('Close'));
     expect(wasCallbackInvoked).toEqual(true);
   });
+
+  it('presents user-triggered content for a specific trigger point', async () => {
+    const Consumer = () => {
+      const { handleEvent } = useWaveCx();
+
+      useEffect(() => {
+        handleEvent({
+          type: 'session-started',
+          userId: 'test-id',
+        });
+      }, [handleEvent]);
+
+      return (
+        <Button
+          title={'Show Content'}
+          onPress={() =>
+            handleEvent({
+              type: 'user-triggered-content',
+              triggerPoint: 'specific-point',
+            })
+          }
+        />
+      );
+    };
+
+    const { getByText } = render(
+      <WaveCxProvider
+        organizationCode={'org'}
+        recordEvent={async () => ({
+          content: [
+            {
+              type: 'featurette',
+              presentationType: 'button-triggered',
+              triggerPoint: 'specific-point',
+              viewUrl: 'https://mock.content.com/embed',
+            },
+            {
+              type: 'featurette',
+              presentationType: 'button-triggered',
+              triggerPoint: 'other-point',
+              viewUrl: 'https://mock.content.com/other',
+            },
+          ],
+        })}
+      >
+        <Consumer />
+      </WaveCxProvider>
+    );
+
+    const user = userEvent.setup();
+    await waitFor(() => {
+      expect(getByText('Show Content')).toBeVisible();
+    });
+    await user.press(getByText('Show Content'));
+
+    await waitFor(() => {
+      expect(getByText(`What's New`)).toBeVisible();
+    });
+  });
+
+  it('presents user-triggered content without a trigger point (legacy behavior)', async () => {
+    const Consumer = () => {
+      const { handleEvent, hasUserTriggeredContent } = useWaveCx();
+
+      useEffect(() => {
+        handleEvent({
+          type: 'session-started',
+          userId: 'test-id',
+        });
+        handleEvent({
+          type: 'trigger-point',
+          triggerPoint: 'trigger-point',
+        });
+      }, [handleEvent]);
+
+      return !hasUserTriggeredContent ? (
+        <></>
+      ) : (
+        <Button
+          title={'Show Content'}
+          onPress={() =>
+            handleEvent({
+              type: 'user-triggered-content',
+            })
+          }
+        />
+      );
+    };
+
+    const { getByText } = render(
+      <WaveCxProvider
+        organizationCode={'org'}
+        recordEvent={async () => ({
+          content: [
+            {
+              type: 'featurette',
+              presentationType: 'button-triggered',
+              triggerPoint: 'trigger-point',
+              viewUrl: 'https://mock.content.com/embed',
+            },
+          ],
+        })}
+      >
+        <Consumer />
+      </WaveCxProvider>
+    );
+
+    const user = userEvent.setup();
+    await waitFor(() => {
+      expect(getByText('Show Content')).toBeVisible();
+    });
+    await user.press(getByText('Show Content'));
+
+    await waitFor(() => {
+      expect(getByText(`What's New`)).toBeVisible();
+    });
+  });
+
+  describe('hasContent', () => {
+    it('returns true when content exists for a trigger point', async () => {
+      let result = false;
+
+      const Consumer = () => {
+        const { handleEvent, hasContent } = useWaveCx();
+
+        useEffect(() => {
+          handleEvent({
+            type: 'session-started',
+            userId: 'test-id',
+          });
+          handleEvent({
+            type: 'trigger-point',
+            triggerPoint: 'check-point',
+          });
+        }, [handleEvent]);
+
+        return (
+          <Button
+            title={'Check'}
+            onPress={() => {
+              result = hasContent('check-point');
+            }}
+          />
+        );
+      };
+
+      const { getByText } = render(
+        <WaveCxProvider
+          organizationCode={'org'}
+          recordEvent={async () => ({
+            content: [
+              {
+                type: 'featurette',
+                presentationType: 'button-triggered',
+                triggerPoint: 'check-point',
+                viewUrl: 'https://mock.content.com/embed',
+              },
+            ],
+          })}
+        >
+          <Consumer />
+        </WaveCxProvider>
+      );
+
+      const user = userEvent.setup();
+      await waitFor(() => {
+        expect(getByText('Check')).toBeVisible();
+      });
+      await user.press(getByText('Check'));
+      expect(result).toBe(true);
+    });
+
+    it('returns false when no content exists for a trigger point', async () => {
+      let result = true;
+
+      const Consumer = () => {
+        const { handleEvent, hasContent } = useWaveCx();
+
+        useEffect(() => {
+          handleEvent({
+            type: 'session-started',
+            userId: 'test-id',
+          });
+          handleEvent({
+            type: 'trigger-point',
+            triggerPoint: 'check-point',
+          });
+        }, [handleEvent]);
+
+        return (
+          <Button
+            title={'Check'}
+            onPress={() => {
+              result = hasContent('no-content-here');
+            }}
+          />
+        );
+      };
+
+      const { getByText } = render(
+        <WaveCxProvider
+          organizationCode={'org'}
+          recordEvent={async () => ({
+            content: [
+              {
+                type: 'featurette',
+                presentationType: 'popup',
+                triggerPoint: 'check-point',
+                viewUrl: 'https://mock.content.com/embed',
+              },
+            ],
+          })}
+        >
+          <Consumer />
+        </WaveCxProvider>
+      );
+
+      const user = userEvent.setup();
+      await waitFor(() => {
+        expect(getByText('Check')).toBeVisible();
+      });
+      await user.press(getByText('Check'));
+      expect(result).toBe(false);
+    });
+
+    it('filters by presentation type when provided', async () => {
+      let popupResult = false;
+      let buttonTriggeredResult = false;
+
+      const Consumer = () => {
+        const { handleEvent, hasContent } = useWaveCx();
+
+        useEffect(() => {
+          handleEvent({
+            type: 'session-started',
+            userId: 'test-id',
+          });
+          handleEvent({
+            type: 'trigger-point',
+            triggerPoint: 'check-point',
+          });
+        }, [handleEvent]);
+
+        return (
+          <Button
+            title={'Check'}
+            onPress={() => {
+              popupResult = hasContent('check-point', 'popup');
+              buttonTriggeredResult = hasContent(
+                'check-point',
+                'button-triggered'
+              );
+            }}
+          />
+        );
+      };
+
+      const { getByText } = render(
+        <WaveCxProvider
+          organizationCode={'org'}
+          recordEvent={async () => ({
+            content: [
+              {
+                type: 'featurette',
+                presentationType: 'button-triggered',
+                triggerPoint: 'check-point',
+                viewUrl: 'https://mock.content.com/embed',
+              },
+            ],
+          })}
+        >
+          <Consumer />
+        </WaveCxProvider>
+      );
+
+      const user = userEvent.setup();
+      await waitFor(() => {
+        expect(getByText('Check')).toBeVisible();
+      });
+      await user.press(getByText('Check'));
+      expect(popupResult).toBe(false);
+      expect(buttonTriggeredResult).toBe(true);
+    });
+
+    it('returns false after session ends', async () => {
+      let result = true;
+
+      const Consumer = () => {
+        const { handleEvent, hasContent } = useWaveCx();
+
+        return (
+          <>
+            <Button
+              title={'Start'}
+              onPress={() => {
+                handleEvent({
+                  type: 'session-started',
+                  userId: 'test-id',
+                });
+                handleEvent({
+                  type: 'trigger-point',
+                  triggerPoint: 'check-point',
+                });
+              }}
+            />
+            <Button
+              title={'End'}
+              onPress={() => {
+                handleEvent({ type: 'session-ended' });
+              }}
+            />
+            <Button
+              title={'Check'}
+              onPress={() => {
+                result = hasContent('check-point');
+              }}
+            />
+          </>
+        );
+      };
+
+      const { getByText } = render(
+        <WaveCxProvider
+          organizationCode={'org'}
+          recordEvent={async () => ({
+            content: [
+              {
+                type: 'featurette',
+                presentationType: 'popup',
+                triggerPoint: 'check-point',
+                viewUrl: 'https://mock.content.com/embed',
+              },
+            ],
+          })}
+        >
+          <Consumer />
+        </WaveCxProvider>
+      );
+
+      const user = userEvent.setup();
+      await user.press(getByText('Start'));
+      await waitFor(() => {
+        expect(getByText('Check')).toBeVisible();
+      });
+      await user.press(getByText('End'));
+      await user.press(getByText('Check'));
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -710,4 +710,261 @@ describe(WaveCxProvider.name, () => {
       expect(result).toBe(false);
     });
   });
+
+  describe('onContentCacheChanged', () => {
+    it('is called when content is fetched', async () => {
+      const onContentCacheChanged = jest.fn();
+      const mockContent = [
+        {
+          type: 'featurette' as const,
+          presentationType: 'popup' as const,
+          triggerPoint: 'trigger-point',
+          viewUrl: 'https://mock.content.com/embed',
+        },
+      ];
+
+      const Consumer = () => {
+        const { handleEvent } = useWaveCx();
+
+        useEffect(() => {
+          handleEvent({
+            type: 'session-started',
+            userId: 'test-id',
+          });
+        }, [handleEvent]);
+
+        return <></>;
+      };
+
+      render(
+        <WaveCxProvider
+          organizationCode={'org'}
+          onContentCacheChanged={onContentCacheChanged}
+          recordEvent={async () => ({
+            content: mockContent,
+          })}
+        >
+          <Consumer />
+        </WaveCxProvider>
+      );
+
+      await waitFor(() => {
+        expect(onContentCacheChanged).toHaveBeenCalledWith(mockContent);
+      });
+    });
+
+    it('is called with empty array when session ends', async () => {
+      const onContentCacheChanged = jest.fn();
+
+      const Consumer = () => {
+        const { handleEvent } = useWaveCx();
+
+        return (
+          <>
+            <Button
+              title={'Start'}
+              onPress={() =>
+                handleEvent({
+                  type: 'session-started',
+                  userId: 'test-id',
+                })
+              }
+            />
+            <Button
+              title={'End'}
+              onPress={() => handleEvent({ type: 'session-ended' })}
+            />
+          </>
+        );
+      };
+
+      const { getByText } = render(
+        <WaveCxProvider
+          organizationCode={'org'}
+          onContentCacheChanged={onContentCacheChanged}
+          recordEvent={async () => ({
+            content: [
+              {
+                type: 'featurette',
+                presentationType: 'popup',
+                triggerPoint: 'trigger-point',
+                viewUrl: 'https://mock.content.com/embed',
+              },
+            ],
+          })}
+        >
+          <Consumer />
+        </WaveCxProvider>
+      );
+
+      const user = userEvent.setup();
+      await user.press(getByText('Start'));
+      await waitFor(() => {
+        expect(onContentCacheChanged).toHaveBeenCalled();
+      });
+
+      onContentCacheChanged.mockClear();
+      await user.press(getByText('End'));
+      expect(onContentCacheChanged).toHaveBeenCalledWith([]);
+    });
+
+    it('is called with empty array on mount', async () => {
+      const onContentCacheChanged = jest.fn();
+
+      const Consumer = () => {
+        return <></>;
+      };
+
+      render(
+        <WaveCxProvider
+          organizationCode={'org'}
+          onContentCacheChanged={onContentCacheChanged}
+          recordEvent={async () => ({
+            content: [],
+          })}
+        >
+          <Consumer />
+        </WaveCxProvider>
+      );
+
+      await waitFor(() => {
+        expect(onContentCacheChanged).toHaveBeenCalledWith([]);
+      });
+    });
+
+    it('is not called again when session starts with no content returned', async () => {
+      const onContentCacheChanged = jest.fn();
+
+      const Consumer = () => {
+        const { handleEvent } = useWaveCx();
+
+        return (
+          <Button
+            title={'Start'}
+            onPress={() =>
+              handleEvent({
+                type: 'session-started',
+                userId: 'test-id',
+              })
+            }
+          />
+        );
+      };
+
+      const { getByText } = render(
+        <WaveCxProvider
+          organizationCode={'org'}
+          onContentCacheChanged={onContentCacheChanged}
+          recordEvent={async () => ({
+            content: [],
+          })}
+        >
+          <Consumer />
+        </WaveCxProvider>
+      );
+
+      await waitFor(() => {
+        expect(onContentCacheChanged).toHaveBeenCalledTimes(1);
+      });
+
+      onContentCacheChanged.mockClear();
+      const user = userEvent.setup();
+      await user.press(getByText('Start'));
+      await waitFor(() => {
+        expect(getByText('Start')).toBeVisible();
+      });
+      expect(onContentCacheChanged).not.toHaveBeenCalled();
+    });
+
+    it('is not called when session ends with an empty cache', async () => {
+      const onContentCacheChanged = jest.fn();
+
+      const Consumer = () => {
+        const { handleEvent } = useWaveCx();
+
+        return (
+          <Button
+            title={'End'}
+            onPress={() => handleEvent({ type: 'session-ended' })}
+          />
+        );
+      };
+
+      const { getByText } = render(
+        <WaveCxProvider
+          organizationCode={'org'}
+          onContentCacheChanged={onContentCacheChanged}
+          recordEvent={async () => ({
+            content: [],
+          })}
+        >
+          <Consumer />
+        </WaveCxProvider>
+      );
+
+      await waitFor(() => {
+        expect(onContentCacheChanged).toHaveBeenCalledTimes(1);
+      });
+
+      onContentCacheChanged.mockClear();
+      const user = userEvent.setup();
+      await user.press(getByText('End'));
+      expect(onContentCacheChanged).not.toHaveBeenCalled();
+    });
+
+    it('is not called on trigger point when no content is consumed', async () => {
+      const onContentCacheChanged = jest.fn();
+
+      const Consumer = () => {
+        const { handleEvent } = useWaveCx();
+
+        useEffect(() => {
+          handleEvent({
+            type: 'session-started',
+            userId: 'test-id',
+          });
+        }, [handleEvent]);
+
+        return (
+          <Button
+            title={'Trigger'}
+            onPress={() =>
+              handleEvent({
+                type: 'trigger-point',
+                triggerPoint: 'no-content-here',
+              })
+            }
+          />
+        );
+      };
+
+      const { getByText } = render(
+        <WaveCxProvider
+          organizationCode={'org'}
+          onContentCacheChanged={onContentCacheChanged}
+          recordEvent={async () => ({
+            content: [
+              {
+                type: 'featurette',
+                presentationType: 'button-triggered',
+                triggerPoint: 'other-point',
+                viewUrl: 'https://mock.content.com/embed',
+              },
+            ],
+          })}
+        >
+          <Consumer />
+        </WaveCxProvider>
+      );
+
+      const user = userEvent.setup();
+      await waitFor(() => {
+        expect(getByText('Trigger')).toBeVisible();
+      });
+
+      onContentCacheChanged.mockClear();
+      await user.press(getByText('Trigger'));
+      expect(onContentCacheChanged).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -364,7 +364,7 @@ describe(WaveCxProvider.name, () => {
 
   it('presents user-triggered content for a specific trigger point', async () => {
     const Consumer = () => {
-      const { handleEvent } = useWaveCx();
+      const { handleEvent, hasContent } = useWaveCx();
 
       useEffect(() => {
         handleEvent({
@@ -373,7 +373,7 @@ describe(WaveCxProvider.name, () => {
         });
       }, [handleEvent]);
 
-      return (
+      return hasContent('specific-point', 'button-triggered') ? (
         <Button
           title={'Show Content'}
           onPress={() =>
@@ -383,6 +383,8 @@ describe(WaveCxProvider.name, () => {
             })
           }
         />
+      ) : (
+        <></>
       );
     };
 
@@ -498,12 +500,15 @@ describe(WaveCxProvider.name, () => {
         }, [handleEvent]);
 
         return (
-          <Button
-            title={'Check'}
-            onPress={() => {
-              result = hasContent('check-point');
-            }}
-          />
+          <>
+            {hasContent('check-point') && <Text>Ready</Text>}
+            <Button
+              title={'Check'}
+              onPress={() => {
+                result = hasContent('check-point');
+              }}
+            />
+          </>
         );
       };
 
@@ -527,7 +532,7 @@ describe(WaveCxProvider.name, () => {
 
       const user = userEvent.setup();
       await waitFor(() => {
-        expect(getByText('Check')).toBeVisible();
+        expect(getByText('Ready')).toBeVisible();
       });
       await user.press(getByText('Check'));
       expect(result).toBe(true);
@@ -535,6 +540,7 @@ describe(WaveCxProvider.name, () => {
 
     it('returns false when no content exists for a trigger point', async () => {
       let result = true;
+      const onContentCacheChanged = jest.fn();
 
       const Consumer = () => {
         const { handleEvent, hasContent } = useWaveCx();
@@ -543,10 +549,6 @@ describe(WaveCxProvider.name, () => {
           handleEvent({
             type: 'session-started',
             userId: 'test-id',
-          });
-          handleEvent({
-            type: 'trigger-point',
-            triggerPoint: 'check-point',
           });
         }, [handleEvent]);
 
@@ -563,6 +565,7 @@ describe(WaveCxProvider.name, () => {
       const { getByText } = render(
         <WaveCxProvider
           organizationCode={'org'}
+          onContentCacheChanged={onContentCacheChanged}
           recordEvent={async () => ({
             content: [
               {
@@ -578,10 +581,15 @@ describe(WaveCxProvider.name, () => {
         </WaveCxProvider>
       );
 
-      const user = userEvent.setup();
       await waitFor(() => {
-        expect(getByText('Check')).toBeVisible();
+        expect(onContentCacheChanged).toHaveBeenLastCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({ triggerPoint: 'check-point' }),
+          ])
+        );
       });
+
+      const user = userEvent.setup();
       await user.press(getByText('Check'));
       expect(result).toBe(false);
     });
@@ -605,16 +613,19 @@ describe(WaveCxProvider.name, () => {
         }, [handleEvent]);
 
         return (
-          <Button
-            title={'Check'}
-            onPress={() => {
-              popupResult = hasContent('check-point', 'popup');
-              buttonTriggeredResult = hasContent(
-                'check-point',
-                'button-triggered'
-              );
-            }}
-          />
+          <>
+            {hasContent('check-point') && <Text>Ready</Text>}
+            <Button
+              title={'Check'}
+              onPress={() => {
+                popupResult = hasContent('check-point', 'popup');
+                buttonTriggeredResult = hasContent(
+                  'check-point',
+                  'button-triggered'
+                );
+              }}
+            />
+          </>
         );
       };
 
@@ -638,7 +649,7 @@ describe(WaveCxProvider.name, () => {
 
       const user = userEvent.setup();
       await waitFor(() => {
-        expect(getByText('Check')).toBeVisible();
+        expect(getByText('Ready')).toBeVisible();
       });
       await user.press(getByText('Check'));
       expect(popupResult).toBe(false);
@@ -800,7 +811,14 @@ describe(WaveCxProvider.name, () => {
       const user = userEvent.setup();
       await user.press(getByText('Start'));
       await waitFor(() => {
-        expect(onContentCacheChanged).toHaveBeenCalled();
+        expect(onContentCacheChanged).toHaveBeenCalledWith([
+          {
+            type: 'featurette',
+            presentationType: 'popup',
+            triggerPoint: 'trigger-point',
+            viewUrl: 'https://mock.content.com/embed',
+          },
+        ]);
       });
 
       onContentCacheChanged.mockClear();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -93,6 +94,7 @@ export const WaveCxProvider = (props: {
   maxFontSizeMultiplier?: number;
   headerTitleStyle?: TextStyle;
   headerCloseButtonStyle?: TextStyle;
+  onContentCacheChanged?: (content: TargetedContent[]) => void;
 }) => {
   const stateRef = useRef({
     isContentLoading: false,
@@ -123,7 +125,12 @@ export const WaveCxProvider = (props: {
     useState(false);
   const [isRemoteContentReady, setIsRemoteContentReady] = useState(false);
   const [, setContentCacheRevision] = useState(0);
-  const invalidateContentCache = () => setContentCacheRevision((r) => r + 1);
+  const onContentCacheChangedRef = useRef(props.onContentCacheChanged);
+  onContentCacheChangedRef.current = props.onContentCacheChanged;
+  const invalidateContentCache = useCallback(() => {
+    setContentCacheRevision((r) => r + 1);
+    onContentCacheChangedRef.current?.([...stateRef.current.contentCache]);
+  }, []);
 
   const presentedContentItem =
     activePopupContent ??
@@ -131,13 +138,19 @@ export const WaveCxProvider = (props: {
 
   const { initiateSession, organizationCode } = props;
 
+  useEffect(() => {
+    onContentCacheChangedRef.current?.([]);
+  }, []);
+
   const handleEvent = useCallback<EventHandler>(
     async (event) => {
       onContentDismissedCallback.current = undefined;
 
       if (event.type === 'session-started') {
-        stateRef.current.contentCache = [];
-        invalidateContentCache();
+        if (stateRef.current.contentCache.length > 0) {
+          stateRef.current.contentCache = [];
+          invalidateContentCache();
+        }
 
         const sessionToken = readSessionToken();
         if (sessionToken) {
@@ -150,7 +163,9 @@ export const WaveCxProvider = (props: {
               userId: event.userId,
             });
             stateRef.current.contentCache = targetedContentResult.content;
-            invalidateContentCache();
+            if (targetedContentResult.content.length > 0) {
+              invalidateContentCache();
+            }
           } catch {}
           stateRef.current.isContentLoading = false;
           if (stateRef.current.eventQueue.length > 0) {
@@ -180,7 +195,9 @@ export const WaveCxProvider = (props: {
               userId: event.userId,
             });
             stateRef.current.contentCache = targetedContentResult.content;
-            invalidateContentCache();
+            if (targetedContentResult.content.length > 0) {
+              invalidateContentCache();
+            }
           } catch {}
           stateRef.current.isContentLoading = false;
           if (stateRef.current.eventQueue.length > 0) {
@@ -204,7 +221,9 @@ export const WaveCxProvider = (props: {
               );
             }
             stateRef.current.contentCache = targetedContentResult.content;
-            invalidateContentCache();
+            if (targetedContentResult.content.length > 0) {
+              invalidateContentCache();
+            }
           } catch {}
           stateRef.current.isContentLoading = false;
           if (stateRef.current.eventQueue.length > 0) {
@@ -213,8 +232,10 @@ export const WaveCxProvider = (props: {
           }
         }
       } else if (event.type === 'session-ended') {
-        stateRef.current.contentCache = [];
-        invalidateContentCache();
+        if (stateRef.current.contentCache.length > 0) {
+          stateRef.current.contentCache = [];
+          invalidateContentCache();
+        }
         setActivePopupContent(undefined);
         setActiveUserTriggeredContent(undefined);
         clearSessionToken();
@@ -247,12 +268,15 @@ export const WaveCxProvider = (props: {
               c.presentationType === 'popup'
           )[0]
         );
+        const prevCacheLength = stateRef.current.contentCache.length;
         stateRef.current.contentCache = stateRef.current.contentCache.filter(
           (c) =>
             c.triggerPoint !== event.triggerPoint ||
             c.presentationType !== 'popup'
         );
-        invalidateContentCache();
+        if (stateRef.current.contentCache.length !== prevCacheLength) {
+          invalidateContentCache();
+        }
         setActiveUserTriggeredContent(
           stateRef.current.contentCache.filter(
             (c) =>
@@ -262,7 +286,7 @@ export const WaveCxProvider = (props: {
         );
       }
     },
-    [organizationCode, initiateSession, recordEvent]
+    [organizationCode, initiateSession, recordEvent, invalidateContentCache]
   );
 
   const hasContent = useCallback(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,6 +48,7 @@ export type Event =
     }
   | {
       type: 'user-triggered-content';
+      triggerPoint?: string;
       onContentDismissed?: () => void;
     };
 
@@ -71,7 +72,12 @@ export type LinkRequestHandler = (
 
 type WaveCxContext = {
   handleEvent: EventHandler;
+  /** @deprecated Use `hasContent(triggerPoint, 'button-triggered')` instead. */
   hasUserTriggeredContent: boolean;
+  hasContent: (
+    triggerPoint: string,
+    presentationType?: 'popup' | 'button-triggered'
+  ) => boolean;
 };
 
 const WaveCxContext = createContext<WaveCxContext | undefined>(undefined);
@@ -116,6 +122,8 @@ export const WaveCxProvider = (props: {
   const [isUserTriggeredContentShown, setIsUserTriggeredContentShown] =
     useState(false);
   const [isRemoteContentReady, setIsRemoteContentReady] = useState(false);
+  const [, setContentCacheRevision] = useState(0);
+  const invalidateContentCache = () => setContentCacheRevision((r) => r + 1);
 
   const presentedContentItem =
     activePopupContent ??
@@ -129,6 +137,7 @@ export const WaveCxProvider = (props: {
 
       if (event.type === 'session-started') {
         stateRef.current.contentCache = [];
+        invalidateContentCache();
 
         const sessionToken = readSessionToken();
         if (sessionToken) {
@@ -141,6 +150,7 @@ export const WaveCxProvider = (props: {
               userId: event.userId,
             });
             stateRef.current.contentCache = targetedContentResult.content;
+            invalidateContentCache();
           } catch {}
           stateRef.current.isContentLoading = false;
           if (stateRef.current.eventQueue.length > 0) {
@@ -170,6 +180,7 @@ export const WaveCxProvider = (props: {
               userId: event.userId,
             });
             stateRef.current.contentCache = targetedContentResult.content;
+            invalidateContentCache();
           } catch {}
           stateRef.current.isContentLoading = false;
           if (stateRef.current.eventQueue.length > 0) {
@@ -193,6 +204,7 @@ export const WaveCxProvider = (props: {
               );
             }
             stateRef.current.contentCache = targetedContentResult.content;
+            invalidateContentCache();
           } catch {}
           stateRef.current.isContentLoading = false;
           if (stateRef.current.eventQueue.length > 0) {
@@ -202,10 +214,19 @@ export const WaveCxProvider = (props: {
         }
       } else if (event.type === 'session-ended') {
         stateRef.current.contentCache = [];
+        invalidateContentCache();
         setActivePopupContent(undefined);
         setActiveUserTriggeredContent(undefined);
         clearSessionToken();
       } else if (event.type === 'user-triggered-content') {
+        if (event.triggerPoint) {
+          const content = stateRef.current.contentCache.find(
+            (c) =>
+              c.triggerPoint === event.triggerPoint &&
+              c.presentationType === 'button-triggered'
+          );
+          setActiveUserTriggeredContent(content);
+        }
         setIsUserTriggeredContentShown(true);
         onContentDismissedCallback.current = event.onContentDismissed;
       } else if (event.type === 'trigger-point') {
@@ -231,6 +252,7 @@ export const WaveCxProvider = (props: {
             c.triggerPoint !== event.triggerPoint ||
             c.presentationType !== 'popup'
         );
+        invalidateContentCache();
         setActiveUserTriggeredContent(
           stateRef.current.contentCache.filter(
             (c) =>
@@ -241,6 +263,21 @@ export const WaveCxProvider = (props: {
       }
     },
     [organizationCode, initiateSession, recordEvent]
+  );
+
+  const hasContent = useCallback(
+    (
+      triggerPoint: string,
+      presentationType?: 'popup' | 'button-triggered'
+    ): boolean => {
+      return stateRef.current.contentCache.some(
+        (c) =>
+          c.triggerPoint === triggerPoint &&
+          (presentationType === undefined ||
+            c.presentationType === presentationType)
+      );
+    },
+    []
   );
 
   const dismissContent = () => {
@@ -255,6 +292,7 @@ export const WaveCxProvider = (props: {
       value={{
         handleEvent,
         hasUserTriggeredContent: activeUserTriggeredContent !== undefined,
+        hasContent,
       }}
     >
       {presentedContentItem && (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -246,6 +246,7 @@ export const WaveCxProvider = (props: {
               c.triggerPoint === event.triggerPoint &&
               c.presentationType === 'button-triggered'
           );
+          if (!content) return;
           setActiveUserTriggeredContent(content);
         }
         setIsUserTriggeredContentShown(true);


### PR DESCRIPTION
## Summary
- Add reactive `hasContent(triggerPoint, presentationType?)` method for checking content availability at any trigger point without consuming it
- Add optional `triggerPoint` param to `user-triggered-content` events for explicit control over which content to present
- Add `onContentCacheChanged` callback prop for syncing content state to external stores
- Deprecate `hasUserTriggeredContent` in favor of `hasContent`
- Bump version to 1.7.0

## Test plan
- [x] All 21 existing + new tests pass
- [x] Type check clean
- [x] Lint and commitlint hooks pass
- [x] Verify `hasContent` reactivity in example app
- [x] Verify `onContentCacheChanged` fires correctly on mount and cache changes