### PR TITLE
fix: scope session tokens to userId

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -15,6 +15,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.73.6",
+    "react-native-safe-area-context": "4.8.2",
     "react-native-web": "~0.19.6",
     "react-native-webview": "13.6.4"
   },

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
+    "react-native-safe-area-context": ">=4.0.0",
     "react-native-webview": "^13.0.0"
   },
   "workspaces": [
@@ -95,7 +96,8 @@
       "<rootDir>/lib/"
     ],
     "moduleNameMapper": {
-      "react-native-webview": "<rootDir>/src/__mocks__/WebView.tsx"
+      "react-native-webview": "<rootDir>/src/__mocks__/WebView.tsx",
+      "react-native-safe-area-context": "<rootDir>/src/__mocks__/SafeAreaContext.tsx"
     }
   },
   "commitlint": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavecx-react-native",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "React Native library for WaveCX",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react": "18.2.0",
     "react-native": "0.73.6",
     "react-native-builder-bob": "^0.23.2",
+    "react-native-safe-area-context": "^4.0.0",
     "react-native-webview": "^13.12.3",
     "react-test-renderer": "^18.3.1",
     "release-it": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react": "18.2.0",
     "react-native": "0.73.6",
     "react-native-builder-bob": "^0.23.2",
-    "react-native-safe-area-context": "^4.0.0",
+    "react-native-safe-area-context": "4.8.2",
     "react-native-webview": "^13.12.3",
     "react-test-renderer": "^18.3.1",
     "release-it": "^15.0.0",

--- a/src/__mocks__/SafeAreaContext.tsx
+++ b/src/__mocks__/SafeAreaContext.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import { View } from 'react-native';
+
+export function SafeAreaProvider({ children }: { children?: ReactNode }) {
+  return <>{children}</>;
+}
+
+export function SafeAreaView({
+  children,
+  ...props
+}: { children?: ReactNode } & Record<string, unknown>) {
+  return <View {...props}>{children}</View>;
+}

--- a/src/__mocks__/SafeAreaContext.tsx
+++ b/src/__mocks__/SafeAreaContext.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import type { ReactNode } from 'react';
 import { View } from 'react-native';
+import type { ViewProps } from 'react-native';
+
+type SafeAreaViewProps = ViewProps & {
+  children?: ReactNode;
+  edges?: Array<'top' | 'right' | 'bottom' | 'left'>;
+};
 
 export function SafeAreaProvider({ children }: { children?: ReactNode }) {
   return <>{children}</>;
@@ -8,7 +14,8 @@ export function SafeAreaProvider({ children }: { children?: ReactNode }) {
 
 export function SafeAreaView({
   children,
+  edges: _edges,
   ...props
-}: { children?: ReactNode } & Record<string, unknown>) {
+}: SafeAreaViewProps) {
   return <View {...props}>{children}</View>;
 }

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -737,6 +737,8 @@ describe(WaveCxProvider.name, () => {
             viewUrl: 'https://mock.content.com/embed',
           },
         ],
+        sessionToken: 'token-a',
+        expiresIn: 3600,
       }));
 
       const Consumer = () => {
@@ -916,9 +918,16 @@ describe(WaveCxProvider.name, () => {
         expect(recordEvent).toHaveBeenCalled();
       });
 
+      recordEvent.mockClear();
       onContentCacheChanged.mockClear();
       await user.press(getByText('Start User B'));
       await waitFor(() => {
+        expect(recordEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'session-started',
+            userId: 'user-b',
+          })
+        );
         expect(onContentCacheChanged).toHaveBeenCalledWith(
           expect.arrayContaining([
             expect.objectContaining({

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -5,8 +5,12 @@ import { render, userEvent, waitFor } from '@testing-library/react-native';
 import '@testing-library/react-native/extend-expect';
 
 import { useWaveCx, WaveCxProvider } from './index';
+import { clearSessionToken } from './sessions';
 
 describe(WaveCxProvider.name, () => {
+  afterEach(() => {
+    clearSessionToken();
+  });
   it('renders provided child elements', () => {
     const { getByText } = render(
       <WaveCxProvider organizationCode={'org'}>
@@ -719,6 +723,210 @@ describe(WaveCxProvider.name, () => {
       await user.press(getByText('End'));
       await user.press(getByText('Check'));
       expect(result).toBe(false);
+    });
+  });
+
+  describe('session-started with different userId', () => {
+    it('initiates a fresh session when userId changes without session-ended', async () => {
+      const recordEvent = jest.fn(async () => ({
+        content: [
+          {
+            type: 'featurette' as const,
+            presentationType: 'popup' as const,
+            triggerPoint: 'trigger-point',
+            viewUrl: 'https://mock.content.com/embed',
+          },
+        ],
+      }));
+
+      const Consumer = () => {
+        const { handleEvent } = useWaveCx();
+
+        return (
+          <>
+            <Button
+              title={'Start User A'}
+              onPress={() =>
+                handleEvent({
+                  type: 'session-started',
+                  userId: 'user-a',
+                })
+              }
+            />
+            <Button
+              title={'Start User B'}
+              onPress={() =>
+                handleEvent({
+                  type: 'session-started',
+                  userId: 'user-b',
+                })
+              }
+            />
+          </>
+        );
+      };
+
+      const { getByText } = render(
+        <WaveCxProvider organizationCode={'org'} recordEvent={recordEvent}>
+          <Consumer />
+        </WaveCxProvider>
+      );
+
+      const user = userEvent.setup();
+      await user.press(getByText('Start User A'));
+      await waitFor(() => {
+        expect(recordEvent).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'session-started', userId: 'user-a' })
+        );
+      });
+
+      recordEvent.mockClear();
+      await user.press(getByText('Start User B'));
+      await waitFor(() => {
+        expect(recordEvent).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'session-started', userId: 'user-b' })
+        );
+      });
+    });
+
+    it('reuses session token when same userId starts a new session', async () => {
+      const recordEvent = jest.fn(async () => ({
+        content: [
+          {
+            type: 'featurette' as const,
+            presentationType: 'popup' as const,
+            triggerPoint: 'trigger-point',
+            viewUrl: 'https://mock.content.com/embed',
+          },
+        ],
+        sessionToken: 'test-token',
+        expiresIn: 3600,
+      }));
+
+      const Consumer = () => {
+        const { handleEvent } = useWaveCx();
+
+        return (
+          <Button
+            title={'Start'}
+            onPress={() =>
+              handleEvent({
+                type: 'session-started',
+                userId: 'same-user',
+              })
+            }
+          />
+        );
+      };
+
+      const { getByText } = render(
+        <WaveCxProvider organizationCode={'org'} recordEvent={recordEvent}>
+          <Consumer />
+        </WaveCxProvider>
+      );
+
+      const user = userEvent.setup();
+      await user.press(getByText('Start'));
+      await waitFor(() => {
+        expect(recordEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'session-started',
+            userId: 'same-user',
+          })
+        );
+      });
+
+      recordEvent.mockClear();
+      await user.press(getByText('Start'));
+      await waitFor(() => {
+        expect(recordEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'session-refresh',
+            userId: 'same-user',
+          })
+        );
+      });
+    });
+
+    it('fetches new content for the new user when userId changes', async () => {
+      const onContentCacheChanged = jest.fn();
+
+      const recordEvent = jest.fn(async (params: { userId?: string }) => {
+        if (params.userId === 'user-b') {
+          return {
+            content: [
+              {
+                type: 'featurette' as const,
+                presentationType: 'popup' as const,
+                triggerPoint: 'trigger-point',
+                viewUrl: 'https://mock.content.com/user-b-content',
+              },
+            ],
+            sessionToken: 'token-b',
+            expiresIn: 3600,
+          };
+        }
+        return {
+          content: [],
+          sessionToken: 'token-a',
+          expiresIn: 3600,
+        };
+      });
+
+      const Consumer = () => {
+        const { handleEvent } = useWaveCx();
+
+        return (
+          <>
+            <Button
+              title={'Start User A'}
+              onPress={() =>
+                handleEvent({
+                  type: 'session-started',
+                  userId: 'user-a',
+                })
+              }
+            />
+            <Button
+              title={'Start User B'}
+              onPress={() =>
+                handleEvent({
+                  type: 'session-started',
+                  userId: 'user-b',
+                })
+              }
+            />
+          </>
+        );
+      };
+
+      const { getByText } = render(
+        <WaveCxProvider
+          organizationCode={'org'}
+          onContentCacheChanged={onContentCacheChanged}
+          recordEvent={recordEvent}
+        >
+          <Consumer />
+        </WaveCxProvider>
+      );
+
+      const user = userEvent.setup();
+      await user.press(getByText('Start User A'));
+      await waitFor(() => {
+        expect(recordEvent).toHaveBeenCalled();
+      });
+
+      onContentCacheChanged.mockClear();
+      await user.press(getByText('Start User B'));
+      await waitFor(() => {
+        expect(onContentCacheChanged).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({
+              viewUrl: 'https://mock.content.com/user-b-content',
+            }),
+          ])
+        );
+      });
     });
   });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,12 +14,12 @@ import {
   Linking,
   Modal,
   Pressable,
-  SafeAreaView,
   StyleSheet,
   Text,
   type TextStyle,
   View,
 } from 'react-native';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import WebView from 'react-native-webview';
 
 import {
@@ -332,8 +332,19 @@ export const WaveCxProvider = (props: {
           animationType={'slide'}
         >
           {presentedContentItem && (
-            <>
-              {presentedContentItem.mobileModal?.type !== 'overFullScreen' && (
+            <SafeAreaProvider>
+              <SafeAreaView
+                style={{
+                  flex: 1,
+                  ...(presentedContentItem.mobileModal?.type ===
+                    'overFullScreen' && {
+                    backgroundColor:
+                      presentedContentItem.mobileModal?.headerColor ??
+                      '#fafafa',
+                  }),
+                }}
+                edges={['top']}
+              >
                 <View
                   style={{
                     ...styles.header,
@@ -374,81 +385,40 @@ export const WaveCxProvider = (props: {
                     </Pressable>
                   </View>
                 </View>
-              )}
-              {presentedContentItem.mobileModal?.type === 'overFullScreen' && (
-                <SafeAreaView
-                  style={{
-                    backgroundColor:
-                      presentedContentItem.mobileModal?.headerColor,
-                  }}
-                >
-                  <View
-                    style={{
-                      ...styles.header,
-                      backgroundColor:
-                        presentedContentItem.mobileModal?.headerColor,
+
+                <View style={styles.contentArea}>
+                  {!isRemoteContentReady && (
+                    <ActivityIndicator style={styles.loadingIndicator} />
+                  )}
+
+                  <WebView
+                    source={{ uri: presentedContentItem.viewUrl }}
+                    style={!isRemoteContentReady ? styles.hidden : undefined}
+                    onLoad={() => setIsRemoteContentReady(true)}
+                    onMessage={(message) => {
+                      try {
+                        const messageData = JSON.parse(
+                          message.nativeEvent.data
+                        );
+                        if (messageData.type === 'link-requested') {
+                          let isDefaultPrevented = false;
+                          props.onLinkRequested?.(messageData.url, {
+                            dismissContent,
+                            preventDefault: () => {
+                              isDefaultPrevented = true;
+                            },
+                          });
+
+                          if (!isDefaultPrevented) {
+                            Linking.openURL(messageData.url);
+                          }
+                        }
+                      } catch {}
                     }}
-                  >
-                    <View style={styles.headerStart} />
-                    <View>
-                      <Text style={styles.headerTitle}>
-                        {presentedContentItem.mobileModal?.title ??
-                          `What's New`}
-                      </Text>
-                    </View>
-                    <View style={styles.closeButtonContainer}>
-                      <Pressable onPress={dismissContent} aria-label={'Close'}>
-                        {presentedContentItem.mobileModal?.closeButton.style ===
-                          'x' && (
-                          <View style={styles.close}>
-                            <View style={styles.closeIcon1} />
-                            <View style={styles.closeIcon2} />
-                          </View>
-                        )}
-                        {presentedContentItem.mobileModal?.closeButton.style !==
-                          'x' && (
-                          <Text>
-                            {presentedContentItem.mobileModal?.closeButton
-                              .style === 'text' &&
-                              presentedContentItem.mobileModal?.closeButton
-                                .label}
-                            {!presentedContentItem.mobileModal && 'Close'}
-                          </Text>
-                        )}
-                      </Pressable>
-                    </View>
-                  </View>
-                </SafeAreaView>
-              )}
-
-              {!isRemoteContentReady && (
-                <ActivityIndicator style={styles.loadingIndicator} />
-              )}
-
-              <WebView
-                source={{ uri: presentedContentItem.viewUrl }}
-                style={!isRemoteContentReady ? styles.hidden : undefined}
-                onLoad={() => setIsRemoteContentReady(true)}
-                onMessage={(message) => {
-                  try {
-                    const messageData = JSON.parse(message.nativeEvent.data);
-                    if (messageData.type === 'link-requested') {
-                      let isDefaultPrevented = false;
-                      props.onLinkRequested?.(messageData.url, {
-                        dismissContent,
-                        preventDefault: () => {
-                          isDefaultPrevented = true;
-                        },
-                      });
-
-                      if (!isDefaultPrevented) {
-                        Linking.openURL(messageData.url);
-                      }
-                    }
-                  } catch {}
-                }}
-              />
-            </>
+                  />
+                </View>
+              </SafeAreaView>
+            </SafeAreaProvider>
           )}
         </Modal>
       )}
@@ -459,6 +429,10 @@ export const WaveCxProvider = (props: {
 };
 
 const styles = StyleSheet.create({
+  contentArea: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+  },
   loadingIndicator: {
     marginTop: '10%',
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -152,7 +152,7 @@ export const WaveCxProvider = (props: {
           invalidateContentCache();
         }
 
-        const sessionToken = readSessionToken();
+        const sessionToken = readSessionToken(event.userId);
         if (sessionToken) {
           try {
             stateRef.current.isContentLoading = true;
@@ -186,7 +186,8 @@ export const WaveCxProvider = (props: {
             });
             storeSessionToken(
               sessionResult.sessionToken,
-              sessionResult.expiresIn ?? 3600
+              sessionResult.expiresIn ?? 3600,
+              event.userId
             );
             const targetedContentResult = await recordEvent({
               organizationCode: organizationCode,
@@ -217,7 +218,8 @@ export const WaveCxProvider = (props: {
             if (targetedContentResult.sessionToken) {
               storeSessionToken(
                 targetedContentResult.sessionToken,
-                targetedContentResult.expiresIn ?? 3600
+                targetedContentResult.expiresIn ?? 3600,
+                event.userId
               );
             }
             stateRef.current.contentCache = targetedContentResult.content;

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -2,20 +2,30 @@ export type SessionToken = string;
 
 let sessionToken: string | null = null;
 let sessionTokenExpiration: Date | null = null;
+let sessionUserId: string | null = null;
 
-export const storeSessionToken = (token: SessionToken, expiresIn: number) => {
+export const storeSessionToken = (
+  token: SessionToken,
+  expiresIn: number,
+  userId: string
+) => {
   sessionToken = token;
   sessionTokenExpiration = new Date(Date.now() + expiresIn * 1000);
+  sessionUserId = userId;
 };
 
 export const clearSessionToken = () => {
   sessionToken = null;
   sessionTokenExpiration = null;
+  sessionUserId = null;
 };
 
-export const readSessionToken = (): SessionToken | null => {
+export const readSessionToken = (userId: string): SessionToken | null => {
   try {
     if (!sessionTokenExpiration) {
+      return null;
+    }
+    if (sessionUserId !== userId) {
       return null;
     }
     return sessionTokenExpiration > new Date() ? sessionToken : null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -14984,6 +14984,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-safe-area-context@npm:4.8.2":
+  version: 4.8.2
+  resolution: "react-native-safe-area-context@npm:4.8.2"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 929eaa5ee522f712e7bfabd0f22908f033918d030c932ddf6a83e4315bc781f7aa44e315806dc8130f75619f09951f3237082f720f4fa65a6670469886cf9735
+  languageName: node
+  linkType: hard
+
 "react-native-web@npm:~0.19.6":
   version: 0.19.11
   resolution: "react-native-web@npm:0.19.11"
@@ -17880,6 +17890,7 @@ __metadata:
     react: 18.2.0
     react-dom: 18.2.0
     react-native: 0.73.6
+    react-native-safe-area-context: 4.8.2
     react-native-web: ~0.19.6
     react-native-webview: 13.6.4
   languageName: unknown
@@ -17914,6 +17925,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
+    react-native-safe-area-context: ">=4.0.0"
     react-native-webview: ^13.0.0
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -17918,6 +17918,7 @@ __metadata:
     react: 18.2.0
     react-native: 0.73.6
     react-native-builder-bob: ^0.23.2
+    react-native-safe-area-context: 4.8.2
     react-native-webview: ^13.12.3
     react-test-renderer: ^18.3.1
     release-it: ^15.0.0


### PR DESCRIPTION
## Summary
- Session tokens are now scoped to the userId, preventing reuse of a stale token when the user changes
- Adds tests for cross-user session invalidation and same-user session reuse
- Bumps version to 1.7.1

## Test plan
- [x] All 24 existing tests pass
- [x] Verify session token is invalidated when userId changes
- [x] Verify session token is reused when the same userId starts a new session