### PR TITLE
fix: support Android 16 edge-to-edge display in content modal

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -15,6 +15,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.73.6",
+    "react-native-safe-area-context": "4.8.2",
     "react-native-web": "~0.19.6",
     "react-native-webview": "13.6.4"
   },

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
+    "react-native-safe-area-context": ">=4.0.0",
     "react-native-webview": "^13.0.0"
   },
   "workspaces": [
@@ -95,7 +96,8 @@
       "<rootDir>/lib/"
     ],
     "moduleNameMapper": {
-      "react-native-webview": "<rootDir>/src/__mocks__/WebView.tsx"
+      "react-native-webview": "<rootDir>/src/__mocks__/WebView.tsx",
+      "react-native-safe-area-context": "<rootDir>/src/__mocks__/SafeAreaContext.tsx"
     }
   },
   "commitlint": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react": "18.2.0",
     "react-native": "0.73.6",
     "react-native-builder-bob": "^0.23.2",
+    "react-native-safe-area-context": "^4.0.0",
     "react-native-webview": "^13.12.3",
     "react-test-renderer": "^18.3.1",
     "release-it": "^15.0.0",

--- a/src/__mocks__/SafeAreaContext.tsx
+++ b/src/__mocks__/SafeAreaContext.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import { View } from 'react-native';
+
+export function SafeAreaProvider({ children }: { children?: ReactNode }) {
+  return <>{children}</>;
+}
+
+export function SafeAreaView({
+  children,
+  ...props
+}: { children?: ReactNode } & Record<string, unknown>) {
+  return <View {...props}>{children}</View>;
+}

--- a/src/__mocks__/SafeAreaContext.tsx
+++ b/src/__mocks__/SafeAreaContext.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import type { ReactNode } from 'react';
 import { View } from 'react-native';
+import type { ViewProps } from 'react-native';
+
+type SafeAreaViewProps = ViewProps & {
+  children?: ReactNode;
+  edges?: Array<'top' | 'right' | 'bottom' | 'left'>;
+};
 
 export function SafeAreaProvider({ children }: { children?: ReactNode }) {
   return <>{children}</>;
@@ -8,7 +14,8 @@ export function SafeAreaProvider({ children }: { children?: ReactNode }) {
 
 export function SafeAreaView({
   children,
+  edges: _edges,
   ...props
-}: { children?: ReactNode } & Record<string, unknown>) {
+}: SafeAreaViewProps) {
   return <View {...props}>{children}</View>;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,12 +14,12 @@ import {
   Linking,
   Modal,
   Pressable,
-  SafeAreaView,
   StyleSheet,
   Text,
   type TextStyle,
   View,
 } from 'react-native';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import WebView from 'react-native-webview';
 
 import {
@@ -332,8 +332,19 @@ export const WaveCxProvider = (props: {
           animationType={'slide'}
         >
           {presentedContentItem && (
-            <>
-              {presentedContentItem.mobileModal?.type !== 'overFullScreen' && (
+            <SafeAreaProvider>
+              <SafeAreaView
+                style={{
+                  flex: 1,
+                  ...(presentedContentItem.mobileModal?.type ===
+                    'overFullScreen' && {
+                    backgroundColor:
+                      presentedContentItem.mobileModal?.headerColor ??
+                      '#fafafa',
+                  }),
+                }}
+                edges={['top']}
+              >
                 <View
                   style={{
                     ...styles.header,
@@ -374,81 +385,40 @@ export const WaveCxProvider = (props: {
                     </Pressable>
                   </View>
                 </View>
-              )}
-              {presentedContentItem.mobileModal?.type === 'overFullScreen' && (
-                <SafeAreaView
-                  style={{
-                    backgroundColor:
-                      presentedContentItem.mobileModal?.headerColor,
-                  }}
-                >
-                  <View
-                    style={{
-                      ...styles.header,
-                      backgroundColor:
-                        presentedContentItem.mobileModal?.headerColor,
+
+                <View style={styles.contentArea}>
+                  {!isRemoteContentReady && (
+                    <ActivityIndicator style={styles.loadingIndicator} />
+                  )}
+
+                  <WebView
+                    source={{ uri: presentedContentItem.viewUrl }}
+                    style={!isRemoteContentReady ? styles.hidden : undefined}
+                    onLoad={() => setIsRemoteContentReady(true)}
+                    onMessage={(message) => {
+                      try {
+                        const messageData = JSON.parse(
+                          message.nativeEvent.data
+                        );
+                        if (messageData.type === 'link-requested') {
+                          let isDefaultPrevented = false;
+                          props.onLinkRequested?.(messageData.url, {
+                            dismissContent,
+                            preventDefault: () => {
+                              isDefaultPrevented = true;
+                            },
+                          });
+
+                          if (!isDefaultPrevented) {
+                            Linking.openURL(messageData.url);
+                          }
+                        }
+                      } catch {}
                     }}
-                  >
-                    <View style={styles.headerStart} />
-                    <View>
-                      <Text style={styles.headerTitle}>
-                        {presentedContentItem.mobileModal?.title ??
-                          `What's New`}
-                      </Text>
-                    </View>
-                    <View style={styles.closeButtonContainer}>
-                      <Pressable onPress={dismissContent} aria-label={'Close'}>
-                        {presentedContentItem.mobileModal?.closeButton.style ===
-                          'x' && (
-                          <View style={styles.close}>
-                            <View style={styles.closeIcon1} />
-                            <View style={styles.closeIcon2} />
-                          </View>
-                        )}
-                        {presentedContentItem.mobileModal?.closeButton.style !==
-                          'x' && (
-                          <Text>
-                            {presentedContentItem.mobileModal?.closeButton
-                              .style === 'text' &&
-                              presentedContentItem.mobileModal?.closeButton
-                                .label}
-                            {!presentedContentItem.mobileModal && 'Close'}
-                          </Text>
-                        )}
-                      </Pressable>
-                    </View>
-                  </View>
-                </SafeAreaView>
-              )}
-
-              {!isRemoteContentReady && (
-                <ActivityIndicator style={styles.loadingIndicator} />
-              )}
-
-              <WebView
-                source={{ uri: presentedContentItem.viewUrl }}
-                style={!isRemoteContentReady ? styles.hidden : undefined}
-                onLoad={() => setIsRemoteContentReady(true)}
-                onMessage={(message) => {
-                  try {
-                    const messageData = JSON.parse(message.nativeEvent.data);
-                    if (messageData.type === 'link-requested') {
-                      let isDefaultPrevented = false;
-                      props.onLinkRequested?.(messageData.url, {
-                        dismissContent,
-                        preventDefault: () => {
-                          isDefaultPrevented = true;
-                        },
-                      });
-
-                      if (!isDefaultPrevented) {
-                        Linking.openURL(messageData.url);
-                      }
-                    }
-                  } catch {}
-                }}
-              />
-            </>
+                  />
+                </View>
+              </SafeAreaView>
+            </SafeAreaProvider>
           )}
         </Modal>
       )}
@@ -459,6 +429,10 @@ export const WaveCxProvider = (props: {
 };
 
 const styles = StyleSheet.create({
+  contentArea: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+  },
   loadingIndicator: {
     marginTop: '10%',
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14984,6 +14984,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-safe-area-context@npm:4.8.2":
+  version: 4.8.2
+  resolution: "react-native-safe-area-context@npm:4.8.2"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 929eaa5ee522f712e7bfabd0f22908f033918d030c932ddf6a83e4315bc781f7aa44e315806dc8130f75619f09951f3237082f720f4fa65a6670469886cf9735
+  languageName: node
+  linkType: hard
+
 "react-native-web@npm:~0.19.6":
   version: 0.19.11
   resolution: "react-native-web@npm:0.19.11"
@@ -17880,6 +17890,7 @@ __metadata:
     react: 18.2.0
     react-dom: 18.2.0
     react-native: 0.73.6
+    react-native-safe-area-context: 4.8.2
     react-native-web: ~0.19.6
     react-native-webview: 13.6.4
   languageName: unknown
@@ -17914,6 +17925,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
+    react-native-safe-area-context: ">=4.0.0"
     react-native-webview: ^13.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary
- Replace RN's built-in `SafeAreaView` (iOS-only) with `react-native-safe-area-context` to properly handle safe area insets inside modals on both platforms
- Prevents modal content from overlapping the status bar on Android 16+ edge-to-edge devices
- Unifies the duplicated `pageSheet`/`overFullScreen` modal branches into a single code path
- Adds white content area background to prevent header color flash while WebView loads

## Breaking change
Adds `react-native-safe-area-context` (`>=4.0.0`) as a **peer dependency**. Most RN apps already have this installed via `react-navigation`.

## Test plan
- [x] Unit tests pass (24/24)
- [x] Verify `pageSheet` modal on iOS — header should render below status bar as before
- [x] Verify `overFullScreen` modal on iOS — header color should fill behind status bar
- [x] Verify `pageSheet` modal on Android 16+ — header should render below status bar (previously overlapped)
- [x] Verify `overFullScreen` modal on Android 16+ — header color should fill behind status bar
- [x] Verify no header color flash while WebView loads on `overFullScreen`